### PR TITLE
fixing 0% value displayed as 100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ certificate.p12
 playwright.config.ts
 * copy.*
 *.wav
+.idea

--- a/src/render/src/components/setup/SettingsTable.vue
+++ b/src/render/src/components/setup/SettingsTable.vue
@@ -66,7 +66,7 @@ const defaultSettings = (devices: AudioDeviceSettings[], scenes: Asset['scene'][
                         const autocamCam = autocamMic?.cams.find((a) => a.source.name === source.name)
                         camsSettings.push({
                             source,
-                            weight: autocamCam?.weight? autocamCam?.weight : (l===m? 100 : 0)
+                          weight: autocamCam?.weight === undefined ? (l===m? 100 : 0) : autocamCam?.weight
                         })
                     }
                     micsSettings.push({


### PR DESCRIPTION
When putting 0% value and saving
![CleanShot 2023-11-01 at 16 36 10@2x](https://github.com/one-click-studio/gabin/assets/6163954/8c9f7866-894f-46c9-bacb-2ad4f6adf272)

It was displayed as a 100% value
![CleanShot 2023-11-01 at 16 36 44@2x](https://github.com/one-click-studio/gabin/assets/6163954/c5633b83-9c2d-47bc-bc90-be996e39d63a)

The problem was coming from the condition 
`autocamCam?.weight ? autocamCam?.weight : (l===m? 100 : 0) `
weight was invalidating the condition when it was 0 which is not exactly what we want. We want to invalidate the condition if it's undefined (I think).

